### PR TITLE
Fixing the error type returned when using -dot

### DIFF
--- a/transdep.go
+++ b/transdep.go
@@ -147,7 +147,7 @@ func spoolDependencyRequest(wc <-chan *dep_msg.Request, ansChan chan<- *WorkerRe
 						ansChan <- &WorkerResult{
 							req.Name(), g.String(), nil, nil,
 							nil, nil, nil, nil,
-							err,
+							nil,
 						}
 					} else {
 						go performBackgroundAnalysis(req.Name(), relNode, ansChan, analysisDoneChan, reqConf, tree)


### PR DESCRIPTION
  The error stack was empty, but the err value itself was not nil.
  This was causing -dot to return an error message, even when there was no
  actual error.